### PR TITLE
LPS-100761

### DIFF
--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -189,7 +189,7 @@ function <portlet:namespace />selectRevision(
 		success: function(event, id, obj) {
 			var parentWindow = Liferay.Util.getOpener();
 
-			parentWindow.location.reload();
+			parentWindow.location = parentWindow.location.href.split('?')[0];
 		}
 	});
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -207,13 +207,11 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 				layoutRevisionId);
 		}
 
-		if ((layoutRevision != null) && !layoutRevision.isInactive()) {
-			return layoutRevision;
+		if ((layoutRevision == null) || layoutRevision.isInactive()) {
+			layoutRevision =
+				LayoutRevisionLocalServiceUtil.fetchLatestLayoutRevision(
+					layoutSetBranchId, layout.getPlid());
 		}
-
-		layoutRevision =
-			LayoutRevisionLocalServiceUtil.fetchLatestLayoutRevision(
-				layoutSetBranchId, layout.getPlid());
 
 		if (layoutRevision != null) {
 			StagingUtil.setRecentLayoutRevisionId(


### PR DESCRIPTION
Hi Robi,

As far as I can see, we already use the _setRecentLayoutRevisionId_ method in the _LayoutStagingHandler_ class, but originally we returned before it was called.

Can't we solve this issue by simply calling it all the time?

My second commit fixes a problem which could be a separate issue as well, but this is strongly related.
I realized that after clicking the workflow task preview, we cannot switch between the revisions using the history tab, because the URL contains the previous revision id and we are stuck.
I cut off the parameters to solve this problem.

Let me know what do you think.

Thanks,
Tamás